### PR TITLE
Fix: Enable relative URLs for local development

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -34,7 +34,7 @@ SOCIAL = (
 DEFAULT_PAGINATION = False
 
 # Uncomment following line if you want document-relative URLs when developing
-# RELATIVE_URLS = True
+RELATIVE_URLS = True
 
 THEME = "themes/newsletter"
 


### PR DESCRIPTION
## Summary
- Enable `RELATIVE_URLS` in `pelicanconf.py` to use relative links instead of absolute URLs for local testing
- Fixes categories and tags pages linking to remote URLs instead of relative paths
- Production builds via `publishconf.py` will continue to use absolute URLs

## Test plan
- [x] Build site locally with `make html` and verify categories/tags use relative URLs
- [x] Build production version with `make publish` and verify absolute URLs are maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)