### PR TITLE
Refactor deployment: Replace submodule with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [release]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install --no-root
+
+      - name: Build site
+        run: poetry run make publish
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./output
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 .directory
 *.svg
+
+# Pelican output
+output/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "output"]
-	path = output
-	url = https://github.com/ngjunsiang/laymansguide.git


### PR DESCRIPTION
## Summary
This PR refactors the deployment workflow from a complex submodule-based approach to a standard GitHub Pages workflow using GitHub Actions.

## Problem
The current deployment uses a submodule-based workflow which:
- Is complex and non-standard
- Requires manual submodule management  
- Causes CI failures when submodule references become invalid
- Doesn't follow GitHub Pages best practices

## Solution
Replace the submodule approach with GitHub Actions for automated deployment.

## Changes

### Added
- `.github/workflows/deploy.yml` - GitHub Actions workflow for automated deployment
- Updated `.gitignore` to exclude `output/` directory

### Removed  
- `.gitmodules` - No longer needed
- Submodule configuration for `output` directory

## New Workflow

**Automated Process:**
1. On push to `release` branch, GitHub Actions triggers
2. Builds site with Poetry + Pelican
3. Deploys output to GitHub Pages automatically

**Manual Deployment:**
```bash
# If needed, can also manually trigger via GitHub Actions UI
# Or build locally: make publish
```

**Benefits:**
- ✅ Standard GitHub Pages workflow
- ✅ No submodule complexity
- ✅ Automatic deployment on release
- ✅ Industry best practices
- ✅ Easier for other developers to understand
- ✅ No more CI submodule failures

## Testing
After merge:
- Push to `release` branch will trigger automatic deployment
- GitHub Actions will build and deploy to GitHub Pages
- Site will be available at `https://ngjunsiang.github.io/laymansguide/`

## Migration Notes
This is a breaking change to the deployment process but doesn't affect:
- Source content structure
- Pelican configuration  
- Build process (still uses `make publish`)
- Development workflow

The only difference is deployment becomes automatic instead of manual.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>